### PR TITLE
Fix: Move cypress config in eslint to inside plugins object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ yarn-error.log*
 
 # submissions
 react-expert-rumpi-submission-1.zip
+dicoding-react-expert-submission-2-rumpi.zip

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,9 +11,9 @@ export default [
   { languageOptions: { globals: { ...globals.browser, ...globals.node } } },
   pluginJs.configs.recommended,
   pluginReact.configs.flat.recommended,
-  pluginCypress.configs.recommended,
   {
     plugins: {
+      'cypress': pluginCypress.configs.recommended,
       'react-hooks': fixupPluginRules(pluginHooks)
     },
     rules: pluginHooks.configs.recommended.rules,


### PR DESCRIPTION
# Summary

Move cypress linter config to inside ESLint plugins object section